### PR TITLE
fix(cdp): disconnect 시 _msg_id 리셋 추가 (H-1)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -188,3 +188,4 @@ Wave 4:                      H-2
 | - | - | - | - | 대기 중 |
 | 2026-03-26 | F-1 (#11) | fix/issue-11-12-response-reading | read_last_response: last 요소만→전체 Array.from+join 결합 | 완료 |
 | 2026-03-26 | F-2 (#12) | fix/issue-11-12-response-reading | default_claude_selectors: response_selector 순서 변경으로 완료 후 매칭 보장 | 완료 |
+| 2026-03-26 | H-1 (#15) | fix/issue-15-disconnect-msgid | disconnect() 시 _msg_id=0 리셋 추가 | 완료 |

--- a/chrome_cdp_controller.py
+++ b/chrome_cdp_controller.py
@@ -216,6 +216,7 @@ class CDPClient:
             except Exception:
                 pass
             self._ws = None
+        self._msg_id = 0  # H-1: 재연결 후 메시지 ID 오염 방지
 
     def send_command(self, method: str, params: dict | None = None) -> dict:
         """CDP 명령을 보내고 응답을 반환한다."""


### PR DESCRIPTION
## 해결 이슈
- Closes #15 (H-1: disconnect _msg_id 리셋 누락)

## 변경 내용

`CDPClient.disconnect()` 호출 시 `_msg_id = 0` 리셋을 추가했습니다.

`if self._ws:` 블록 **밖**에 위치하여 ws가 이미 None인 상태에서 중복 disconnect가 호출되어도 항상 카운터가 리셋됩니다.

## 영향 범위
`CDPClient.disconnect` / 재연결 시 메시지 ID 오염 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)