### PR TITLE
fix(discussion): 응답 텍스트 읽기 개선 (F-1, F-2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -186,3 +186,5 @@ Wave 4:                      H-2
 | 날짜 | 이슈 | 브랜치 | 수정 요약 | 상태 |
 |------|------|--------|-----------|------|
 | - | - | - | - | 대기 중 |
+| 2026-03-26 | F-1 (#11) | fix/issue-11-12-response-reading | read_last_response: last 요소만→전체 Array.from+join 결합 | 완료 |
+| 2026-03-26 | F-2 (#12) | fix/issue-11-12-response-reading | default_claude_selectors: response_selector 순서 변경으로 완료 후 매칭 보장 | 완료 |

--- a/discussion_app.py
+++ b/discussion_app.py
@@ -48,7 +48,9 @@ def default_claude_selectors() -> SelectorConfig:
     return SelectorConfig(
         input_selector='div[contenteditable="true"].ProseMirror',
         send_selector='button[aria-label="Send Message"]',
-        response_selector='[data-is-streaming] .markdown-content, .font-claude-message .markdown-content',
+        # F-2: 스트리밍/완료 양쪽 상태에서 매칭되는 복합 선택자
+        # .font-claude-message를 우선으로, 스트리밍 중 폴백으로 [data-is-streaming] 포함
+        response_selector='.font-claude-message .markdown-content, [data-is-streaming] .markdown-content',
         stop_button_selector='button[aria-label="Stop Response"]',
     )
 
@@ -336,14 +338,17 @@ class AITabController:
         return resp.get("result", {}).get("result", {}).get("value", False)
 
     def read_last_response(self) -> str:
-        """마지막 응답 텍스트를 추출한다."""
+        """응답 텍스트를 모든 매칭 요소에서 결합하여 반환한다."""
         sel = self.selectors.response_selector
         js = f"""
         (() => {{
             const els = document.querySelectorAll({json.dumps(sel)});
             if (els.length === 0) return '';
-            const last = els[els.length - 1];
-            return last.innerText || last.textContent || '';
+            // F-1: 전체 요소 텍스트 결합 (스트리밍 분할 블록 대응)
+            return Array.from(els)
+                .map(e => (e.innerText || e.textContent || '').trim())
+                .filter(Boolean)
+                .join('\\n');
         }})()
         """
         resp = self.cdp.execute_js(js)


### PR DESCRIPTION
## 해결 이슈
- Closes #11 (F-1: read_last_response 마지막 요소만 반환)
- Closes #12 (F-2: Claude response_selector 스트리밍 완료 후 미매칭)

## 변경 내용

### F-1: read_last_response()
스트리밍 중 응답이 여러 DOM 블록으로 분리될 때 마지막 블록만 캡처하던 문제를 수정.

```js
// 수정 전
const last = els[els.length - 1];
return last.innerText || last.textContent || '';

// 수정 후
return Array.from(els)
    .map(e => (e.innerText || e.textContent || '').trim())
    .filter(Boolean)
    .join('\n');
```

### F-2: default_claude_selectors()
`[data-is-streaming]`은 스트리밍 중에만 존재합니다.
스트리밍 완료 후에도 안정적으로 매칭되도록 `.font-claude-message` 선택자를 우선 배치.

## 영향 범위
`AITabController.read_last_response`, `default_claude_selectors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)