### PR TITLE
fix(cdp): send_command WebSocket 수신 루프 안정화 (A-1, A-2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -191,3 +191,5 @@ Wave 4:                      H-2
 | 2026-03-26 | H-1 (#15) | fix/issue-15-disconnect-msgid | disconnect() 시 _msg_id=0 리셋 추가 | 완료 |
 | 2026-03-26 | E-1 (#9) | fix/issue-9-10-istrusted-events | click(): JS .click() → CDP Input.dispatchMouseEvent (isTrusted:true) | 완료 |
 | 2026-03-26 | E-2 (#10) | fix/issue-9-10-istrusted-events | press_enter(): JS dispatchEvent → CDP Input.dispatchKeyEvent (isTrusted:true) | 완료 |
+| 2026-03-26 | A-1 (#1) | fix/issue-1-2-send-command | send_command WebSocketTimeoutException: break→continue | 완료 |
+| 2026-03-26 | A-2 (#2) | fix/issue-1-2-send-command | send_command 이벤트 메시지 explicit continue 추가 | 완료 |

--- a/chrome_cdp_controller.py
+++ b/chrome_cdp_controller.py
@@ -235,8 +235,11 @@ class CDPClient:
                 resp = json.loads(raw)
                 if resp.get("id") == msg_id:
                     return resp
+                # A-2: CDP 비동기 이벤트 메시지 (id 없음) — 무시하고 계속 대기
+                continue
             except websocket.WebSocketTimeoutException:
-                break
+                # A-1: break → continue — 데드라인까지 재시도
+                continue
             except Exception as e:
                 return {"error": {"message": str(e)}}
 


### PR DESCRIPTION
## 해결 이슈
- Closes #1 (A-1: WebSocketTimeoutException break→continue)
- Closes #2 (A-2: CDP 이벤트 메시지 explicit continue)

## 변경 내용

### A-1
`WebSocketTimeoutException` 발생 시 `break`로 루프를 즉시 탈출하던 문제를 `continue`로 수정.
15초 데드라인이 남아있는 경우 재시도합니다.

### A-2
CDP 비동기 이벤트 메시지(`id` 없음)를 수신했을 때 `continue`를 명시적으로 추가.
요청 응답과 이벤트 메시지의 처리 흐름을 명확히 분리합니다.

## 영향 범위
`CDPClient.send_command` — 모든 CDP 명령 전송의 기반 함수

🤖 Generated with [Claude Code](https://claude.com/claude-code)