### PR TITLE
fix(cdp): CDP 입력 메커니즘 전면 개선 (B-1~D-2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -193,3 +193,9 @@ Wave 4:                      H-2
 | 2026-03-26 | E-2 (#10) | fix/issue-9-10-istrusted-events | press_enter(): JS dispatchEvent → CDP Input.dispatchKeyEvent (isTrusted:true) | 완료 |
 | 2026-03-26 | A-1 (#1) | fix/issue-1-2-send-command | send_command WebSocketTimeoutException: break→continue | 완료 |
 | 2026-03-26 | A-2 (#2) | fix/issue-1-2-send-command | send_command 이벤트 메시지 explicit continue 추가 | 완료 |
+| 2026-03-26 | B-1 (#3) | fix/issue-3-4-5-6-7-8-cdp-input | connect_tab: Target.activateTarget + _active_target_id 저장 | 완료 |
+| 2026-03-26 | B-2 (#4) | fix/issue-3-4-5-6-7-8-cdp-input | type_contenteditable: Input.insertText 전 activateTarget 재확인 | 완료 |
+| 2026-03-26 | C-1 (#5) | fix/issue-3-4-5-6-7-8-cdp-input | type_contenteditable: innerHTML='' → Selection API+CDP Delete 클리어 | 완료 |
+| 2026-03-26 | C-2 (#6) | fix/issue-3-4-5-6-7-8-cdp-input | type_contenteditable: 클리어 후 검증 + execCommand 폴백 추가 | 완료 |
+| 2026-03-26 | D-1 (#7) | fix/issue-3-4-5-6-7-8-cdp-input | _verify_input_content: activeElement→selector 파라미터 기반 검증 | 완료 |
+| 2026-03-26 | D-2 (#8) | fix/issue-3-4-5-6-7-8-cdp-input | _verify_input_content: 길이>0→expected_text 포함 여부 비교 | 완료 |

--- a/chrome_cdp_controller.py
+++ b/chrome_cdp_controller.py
@@ -190,6 +190,7 @@ class CDPClient:
         self.port = port
         self._ws: websocket.WebSocket | None = None
         self._msg_id = 0
+        self._active_target_id: str = ""
 
     @property
     def connected(self) -> bool:
@@ -205,9 +206,13 @@ class CDPClient:
             return []
 
     def connect_tab(self, ws_url: str):
-        """특정 탭에 WebSocket으로 연결한다."""
+        """특정 탭에 WebSocket으로 연결하고 활성화한다."""
         self.disconnect()
         self._ws = websocket.create_connection(ws_url, timeout=10)
+        # B-1: Input.* 명령이 올바른 탭에 적용되도록 탭 활성화
+        # ws_url에서 targetId 파싱: "ws://localhost:PORT/devtools/page/{targetId}"
+        self._active_target_id = ws_url.rstrip("/").split("/")[-1]
+        self.send_command("Target.activateTarget", {"targetId": self._active_target_id})
 
     def disconnect(self):
         if self._ws:
@@ -305,7 +310,7 @@ class CDPClient:
         """contenteditable div에 텍스트 입력 (3단계 전략: CDP insertText → dispatchKeyEvent → execCommand)"""
         selectors = [selector] + (fallback_selectors or [])
 
-        # Step 0: JS로 요소를 찾고 focus + 기존 내용 제거
+        # Step 0: JS로 요소를 찾고 focus + Selection API로 기존 내용 클리어 (React DOM 유지)
         focus_js = f"""
         (() => {{
             const selectors = {json.dumps(selectors)};
@@ -316,7 +321,12 @@ class CDPClient:
             }}
             if (!el) return 'Element not found: ' + selectors.join(', ');
             el.focus();
-            el.innerHTML = '';
+            // C-1: innerHTML='' 대신 Selection API로 전체 선택 후 React 친화적 클리어
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
             return 'FOCUSED';
         }})()
         """
@@ -325,16 +335,48 @@ class CDPClient:
         if "not found" in result_val.lower():
             return resp
 
+        # Selection 후 Delete 키로 내용 삭제 (isTrusted: true)
+        self.send_command("Input.dispatchKeyEvent", {
+            "type": "keyDown", "key": "Delete", "code": "Delete",
+            "windowsVirtualKeyCode": 46, "nativeVirtualKeyCode": 46,
+        })
+        self.send_command("Input.dispatchKeyEvent", {
+            "type": "keyUp", "key": "Delete", "code": "Delete",
+            "windowsVirtualKeyCode": 46, "nativeVirtualKeyCode": 46,
+        })
+
+        # C-2: 클리어 검증
+        clear_verify_js = f"""
+        (() => {{
+            const selectors = {json.dumps(selectors)};
+            let el = null;
+            for (const sel of selectors) {{
+                el = document.querySelector(sel);
+                if (el) break;
+            }}
+            if (!el) return false;
+            return (el.innerText || el.textContent || '').trim() === '';
+        }})()
+        """
+        clear_ok = self.execute_js(clear_verify_js).get("result", {}).get("result", {}).get("value", False)
+        if not clear_ok:
+            # 클리어 실패 시 execCommand 폴백
+            self.execute_js("document.execCommand('selectAll', false, null)")
+            self.execute_js("document.execCommand('delete', false, null)")
+
+        # B-2: Input.insertText 전 탭 활성화 재확인
+        if hasattr(self, '_active_target_id') and self._active_target_id:
+            self.send_command("Target.activateTarget", {"targetId": self._active_target_id})
+
         # Step 1: CDP Input.insertText (가장 자연스러운 네이티브 입력)
         insert_resp = self.send_command("Input.insertText", {"text": text})
         if "error" not in insert_resp:
-            verify = self._verify_input_content()
+            verify = self._verify_input_content(selector, text)
             if verify:
                 return {"result": {"result": {"value": "OK (CDP insertText)"}}}
 
         # Step 2: CDP Input.dispatchKeyEvent (글자별 전송, 500자 이하만)
         if len(text) <= 500:
-            # focus 재설정
             self.execute_js(focus_js)
             success = True
             for char in text:
@@ -354,7 +396,7 @@ class CDPClient:
                     "code": "",
                 })
             if success:
-                verify = self._verify_input_content()
+                verify = self._verify_input_content(selector, text)
                 if verify:
                     return {"result": {"result": {"value": "OK (CDP dispatchKeyEvent)"}}}
 
@@ -377,16 +419,30 @@ class CDPClient:
         """
         return self.execute_js(legacy_js)
 
-    def _verify_input_content(self) -> bool:
-        """활성 요소에 텍스트가 실제로 입력되었는지 확인"""
-        verify_js = """
-        (() => {
-            const el = document.activeElement;
-            if (!el) return false;
-            const content = (el.innerText || el.textContent || '').trim();
-            return content.length > 0;
-        })()
+    def _verify_input_content(self, selector: str, expected_text: str = "") -> bool:
+        """입력된 요소에 expected_text 앞부분이 실제로 포함되었는지 확인한다.
+        D-1: activeElement 대신 selector 기반으로 검증
+        D-2: 텍스트 길이 > 0 대신 expected_text 포함 여부 비교
         """
+        if expected_text:
+            snippet = json.dumps(expected_text[:30])
+            verify_js = f"""
+            (() => {{
+                const el = document.querySelector({json.dumps(selector)});
+                if (!el) return false;
+                const content = (el.innerText || el.textContent || '').trim();
+                return content.includes({snippet});
+            }})()
+            """
+        else:
+            verify_js = f"""
+            (() => {{
+                const el = document.querySelector({json.dumps(selector)});
+                if (!el) return false;
+                const content = (el.innerText || el.textContent || '').trim();
+                return content.length > 0;
+            }})()
+            """
         resp = self.execute_js(verify_js)
         return resp.get("result", {}).get("result", {}).get("value", False)
 


### PR DESCRIPTION
## 해결 이슈
- Closes #3 (B-1: connect_tab activateTarget)
- Closes #4 (B-2: insertText 전 activateTarget 재확인)
- Closes #5 (C-1: innerHTML='' → Selection API 클리어)
- Closes #6 (C-2: 클리어 후 검증)
- Closes #7 (D-1: _verify_input_content selector 기반)
- Closes #8 (D-2: expected_text 포함 여부 검증)

## 변경 내용

### B-1: connect_tab 탭 활성화
`Target.activateTarget`을 호출하여 WebSocket 연결 직후 해당 탭을 OS 수준에서 활성화합니다.
`_active_target_id`에 targetId를 저장하여 이후 재확인에 활용합니다.

### B-2: insertText 전 활성화 재확인
복수 탭 교대 제어 시 포커스 이탈 방지를 위해 `Input.insertText` 직전에 `Target.activateTarget`을 재호출합니다.

### C-1: React 친화적 클리어
`el.innerHTML = ''` 제거 → Selection API(`createRange` + `selectNodeContents`) + CDP `Input.dispatchKeyEvent(Delete)`로 교체합니다.
React virtual DOM 상태를 유지하면서 내용을 클리어합니다.

### C-2: 클리어 검증
Delete 키 전송 후 실제로 비어있는지 JS로 검증합니다.
실패 시 `document.execCommand('selectAll')` + `execCommand('delete')` 폴백을 실행합니다.

### D-1/D-2: _verify_input_content 개선
- `document.activeElement` → `document.querySelector(selector)` 직접 조회
- 텍스트 길이 > 0 → `expected_text` 앞 30자 포함 여부로 검증 강화

## 영향 범위
`CDPClient.connect_tab`, `type_contenteditable`, `_verify_input_content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)