### PR TITLE
fix(discussion): wait_for_response 단일 루프 통합 (G-1, G-2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -199,3 +199,5 @@ Wave 4:                      H-2
 | 2026-03-26 | C-2 (#6) | fix/issue-3-4-5-6-7-8-cdp-input | type_contenteditable: 클리어 후 검증 + execCommand 폴백 추가 | 완료 |
 | 2026-03-26 | D-1 (#7) | fix/issue-3-4-5-6-7-8-cdp-input | _verify_input_content: activeElement→selector 파라미터 기반 검증 | 완료 |
 | 2026-03-26 | D-2 (#8) | fix/issue-3-4-5-6-7-8-cdp-input | _verify_input_content: 길이>0→expected_text 포함 여부 비교 | 완료 |
+| 2026-03-26 | G-1 (#13) | fix/issue-13-14-wait-for-response | wait_for_response: 두 루프→단일 루프 통합, 타이밍 경쟁 조건 해결 | 완료 |
+| 2026-03-26 | G-2 (#14) | fix/issue-13-14-wait-for-response | G-1 구현+F-1 read_last_response 수정으로 stable_duration 전체 텍스트 기준 보장 | 완료 |

--- a/discussion_app.py
+++ b/discussion_app.py
@@ -359,51 +359,57 @@ class AITabController:
                           stable_duration: float = 3.0) -> tuple[bool, str]:
         """응답 완료를 대기한다.
 
-        전략: poll_interval 간격으로 응답을 확인하고,
-        stable_duration 동안 텍스트 변경 없음 + Stop 버튼 사라짐 → 완료 판정
+        G-1: 스트리밍 시작 대기 루프와 완료 판정 루프를 단일 루프로 통합.
+        전략: timeout까지 단일 루프로 polling하며,
+        응답이 시작되면 stable_duration 동안 텍스트 변경 없음 + Stop 버튼 사라짐 → 완료 판정.
         """
         start = time.time()
-        last_text = ""
+        last_text = self._last_response   # baseline 기준
         stable_since: float | None = None
-
-        # 먼저 스트리밍이 시작될 때까지 대기 (최대 15초)
-        stream_wait_start = time.time()
-        while time.time() - stream_wait_start < 15:
-            current = self.read_last_response()
-            if current and current != self._last_response:
-                break
-            if self.is_streaming():
-                break
-            time.sleep(1)
+        response_started = False
 
         while time.time() - start < timeout:
+            if self._stop_check():
+                break
             current = self.read_last_response()
             streaming = self.is_streaming()
 
-            if current != last_text:
-                last_text = current
-                stable_since = None
-            else:
-                if stable_since is None:
-                    stable_since = time.time()
+            # 응답 시작 감지 (baseline과 달라지거나 스트리밍 중)
+            if not response_started:
+                if current != self._last_response or streaming:
+                    response_started = True
 
-            # 안정성 검사: 텍스트 변경 없음 + Stop 버튼 없음
-            if (stable_since is not None
-                    and time.time() - stable_since >= stable_duration
-                    and not streaming
-                    and current
-                    and current != self._last_response):
-                self._last_response = current
-                return True, current
+            if response_started:
+                if current != last_text:
+                    # 텍스트 변경 → stable 타이머 리셋
+                    last_text = current
+                    stable_since = None
+                else:
+                    # 텍스트 변경 없음 → stable 타이머 시작
+                    if stable_since is None:
+                        stable_since = time.time()
+
+                # 완료 조건: stable_duration 유지 + 스트리밍 종료 + 내용 있음 + baseline과 다름
+                if (stable_since is not None
+                        and time.time() - stable_since >= stable_duration
+                        and not streaming
+                        and current
+                        and current != self._last_response):
+                    self._last_response = current
+                    return True, current
 
             time.sleep(poll_interval)
 
-        # 타임아웃
+        # 타임아웃 시 마지막 시도
         current = self.read_last_response()
         if current and current != self._last_response:
             self._last_response = current
             return True, current
         return False, "응답 타임아웃"
+
+    def _stop_check(self) -> bool:
+        """서브클래스나 외부에서 중단 요청 여부를 확인한다. 기본값: False"""
+        return False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 해결 이슈
- Closes #13 (G-1: wait_for_response 두 루프 타이밍 경쟁 조건)
- Closes #14 (G-2: stable_duration 불완전한 텍스트 기준 판정)

## 변경 내용

### G-1: 단일 루프 통합
기존 스트리밍 시작 대기 루프(15초) + 완료 판정 루프(timeout)를 단일 루프로 통합.

- `response_started` 플래그: 응답이 시작되기 전에는 `stable_since` 타이머를 동작시키지 않음
- `last_text`를 `self._last_response`(baseline)로 초기화: 루프 시작 즉시 stable 타이머가 잘못 시작되는 현상 방지
- 완료 조건에 `current != self._last_response` 추가: baseline과 동일한 텍스트로 완료 판정하는 오류 방지

### G-2
F-1에서 `read_last_response`가 `Array.from+join` 전체 텍스트 결합으로 수정되어 있으므로, G-1 구현으로 자동 해결.

### _stop_check()
향후 외부에서 중단 신호를 주입할 수 있는 확장 포인트. 기본값 `False` 반환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)